### PR TITLE
feat(config): extend .env.example with DB vars and wire APP_DB_URL in…

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,5 @@
+# App environment
 APP_ENV=local
-APP_DB_URL=postgresql://user:pass@localhost:5432/hybrid_ai
 DEBUG=true
 
 # Postgres (local Docker)
@@ -10,8 +10,10 @@ APP_DB_HOST=localhost
 APP_DB_PORT=5432
 
 # Async SQLAlchemy URL (used by the app + alembic)
+# NOTE: assembled dynamically in settings.py if not explicitly set
 APP_DB_URL=postgresql+asyncpg://${APP_DB_USER}:${APP_DB_PASSWORD}@${APP_DB_HOST}:${APP_DB_PORT}/${APP_DB_NAME}
 
-# Optional pgAdmin
+# Optional pgAdmin (UI for Postgres)
 PGADMIN_EMAIL=admin@example.com
 PGADMIN_PASSWORD=adminpass
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,7 @@
-fastapi
-uvicorn[standard]pydantic>=2.6
+fastapi>=0.115
+uvicorn[standard]>=0.30
+pydantic>=2.6
 pydantic-settings>=2.2
+SQLAlchemy[asyncio]>=2.0
+asyncpg>=0.29
+python-dotenv>=1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 fastapi
-uvicorn[standard]
+uvicorn[standard]pydantic>=2.6
+pydantic-settings>=2.2

--- a/src/config/settings.py
+++ b/src/config/settings.py
@@ -1,11 +1,45 @@
-"""App settings placeholder (env parsing goes here)."""
-
-import os
-
-
-class Settings:
-    ENV: str = os.getenv("ENV", "local")
-    DEBUG: bool = os.getenv("DEBUG", "true").lower() == "true"
+from functools import lru_cache
+from pydantic import field_validator
+from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
-settings = Settings()
+class Settings(BaseSettings):
+    # Read from .env; ignore unexpected keys to be resilient
+    model_config = SettingsConfigDict(
+        env_file=".env",
+        case_sensitive=False,
+        extra="ignore",  # <- important: don't error on unrelated env vars
+    )
+
+    # General
+    app_env: str = "local"  # maps to APP_ENV
+    debug: bool = True      # maps to DEBUG
+
+    # DB pieces
+    app_db_user: str = "appuser"
+    app_db_password: str = "apppass"
+    app_db_name: str = "appdb"
+    app_db_host: str = "localhost"
+    app_db_port: int = 5432
+    app_db_url: str | None = None  # optional override
+
+    # Optional pgAdmin (present in .env for docker-compose)
+    pgadmin_email: str | None = None     # maps to PGADMIN_EMAIL
+    pgadmin_password: str | None = None  # maps to PGADMIN_PASSWORD
+
+    @field_validator("app_db_url", mode="before")
+    @classmethod
+    def assemble_db_url(cls, v: str | None, values: dict):
+        if v:
+            return v
+        user = values.get("app_db_user")
+        pw = values.get("app_db_password")
+        host = values.get("app_db_host")
+        port = values.get("app_db_port")
+        name = values.get("app_db_name")
+        return f"postgresql+asyncpg://{user}:{pw}@{host}:{port}/{name}"
+
+
+@lru_cache
+def get_settings() -> Settings:
+    return Settings()

--- a/src/config/settings.py
+++ b/src/config/settings.py
@@ -13,7 +13,7 @@ class Settings(BaseSettings):
 
     # General
     app_env: str = "local"  # maps to APP_ENV
-    debug: bool = True      # maps to DEBUG
+    debug: bool = True  # maps to DEBUG
 
     # DB pieces
     app_db_user: str = "appuser"
@@ -24,7 +24,7 @@ class Settings(BaseSettings):
     app_db_url: str | None = None  # optional override
 
     # Optional pgAdmin (present in .env for docker-compose)
-    pgadmin_email: str | None = None     # maps to PGADMIN_EMAIL
+    pgadmin_email: str | None = None  # maps to PGADMIN_EMAIL
     pgadmin_password: str | None = None  # maps to PGADMIN_PASSWORD
 
     @field_validator("app_db_url", mode="before")


### PR DESCRIPTION
## What
- Extended `.env.example` with Postgres variables:
  - `APP_DB_USER`
  - `APP_DB_PASSWORD`
  - `APP_DB_NAME`
  - `APP_DB_HOST`
  - `APP_DB_PORT`
- Cleaned up duplicate `APP_DB_URL` entries and standardised on async driver (`postgresql+asyncpg`).
- Updated `src/config/settings.py` to load DB config via **Pydantic v2 + pydantic-settings**.
- Added `pgadmin_email` / `pgadmin_password` fields so optional pgAdmin vars don’t break validation.
- Config now builds `APP_DB_URL` dynamically if not explicitly set.

## Why
- `.env.example` provides a clear template for required vars while keeping real secrets in `.env`.
- Pydantic v2 settings approach is future-proof, typed, and recruiter-friendly.
- Async URL ensures compatibility with SQLAlchemy 2.0 + asyncpg.
- Adds enterprise credibility by showing proper secrets handling and config discipline.

## How to test
1. Copy `.env.example` → `.env`.
2. Run inside the venv:
   ```bash
   python -c "from src.config.settings import get_settings; print(get_settings().app_db_url)"

Expected output: postgresql+asyncpg://appuser:apppass@localhost:5432/appdb
