### PR TITLE
feat(db): add async SQLAchemy engine, session factory, and FastAPI de…

### DIFF
--- a/src/api/app.py
+++ b/src/api/app.py
@@ -1,23 +1,61 @@
-"""Minimal FastAPI app placeholder."""
+from __future__ import annotations
 
-try:
-    from fastapi import FastAPI
-except Exception:
-    # Allow repo to import without dependencies installed
-    class FastAPI:  # type: ignore
-        def __init__(self, *_, **__):
-            pass
+from contextlib import asynccontextmanager
+from typing import Any, Dict
 
-        def get(self, *_args, **_kwargs):
-            def decorator(fn):
-                return fn
+from fastapi import FastAPI
+from sqlalchemy import text
 
-            return decorator
+from src.config.settings import get_settings
+from src.db.session import dispose_engine, engine
+
+settings = get_settings()
 
 
-app = FastAPI()
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    """
+    App lifecycle:
+    - Startup: (hook for warmups, migrations triggers, cache, etc.)
+    - Shutdown: dispose SQLAlchemy engine cleanly.
+    """
+    # --- startup work (optional) ---
+    # e.g., ping DB once, warm caches, load config, etc.
+    try:
+        async with engine.connect() as conn:
+            await conn.execute(text("SELECT 1"))
+    except Exception:
+        # We don't fail the app on cold start if DB isn't up yet;
+        # the /health endpoint will surface status.
+        pass
+
+    yield
+
+    # --- shutdown work ---
+    await dispose_engine()
+
+
+app = FastAPI(title="Hybrid AI Platform", lifespan=lifespan)
 
 
 @app.get("/health")
-def health():
-    return {"status": "ok"}
+async def health() -> Dict[str, Any]:
+    """
+    Basic health endpoint:
+    - reports environment
+    - reports DB connectivity (best-effort, non-fatal)
+    """
+    db_ok = False
+    try:
+        async with engine.connect() as conn:
+            result = await conn.execute(text("SELECT 1"))
+            db_ok = (result.scalar_one() == 1)
+    except Exception:
+        db_ok = False
+
+    return {
+        "status": "ok" if db_ok else "degraded",
+        "env": settings.app_env,
+        "db": "up" if db_ok else "down",
+    }
+

--- a/src/api/app.py
+++ b/src/api/app.py
@@ -49,7 +49,7 @@ async def health() -> Dict[str, Any]:
     try:
         async with engine.connect() as conn:
             result = await conn.execute(text("SELECT 1"))
-            db_ok = (result.scalar_one() == 1)
+            db_ok = result.scalar_one() == 1
     except Exception:
         db_ok = False
 
@@ -58,4 +58,3 @@ async def health() -> Dict[str, Any]:
         "env": settings.app_env,
         "db": "up" if db_ok else "down",
     }
-

--- a/src/db/session.py
+++ b/src/db/session.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+from typing import AsyncIterator
+
+from sqlalchemy.ext.asyncio import (
+    AsyncEngine,
+    AsyncSession,
+    async_sessionmaker,
+    create_async_engine,
+)
+from sqlalchemy.orm import DeclarativeBase
+from src.config.settings import get_settings
+
+
+# ---- Declarative base for your ORM models ----
+class Base(DeclarativeBase):
+    """Base class for SQLAlchemy ORM models."""
+    pass
+
+
+# ---- Engine & Session Factory (module-level singletons) ----
+_settings = get_settings()
+
+# Create the async engine from env-driven URL, with sane defaults
+engine: AsyncEngine = create_async_engine(
+    _settings.app_db_url,
+    echo=False,           # flip to True locally if you want SQL in logs
+    pool_pre_ping=True,   # validates connections before using them
+    future=True,          # SQLAlchemy 2.0 style
+)
+
+# Session factory; each request gets its own session
+AsyncSessionLocal = async_sessionmaker(
+    bind=engine,
+    expire_on_commit=False,  # keeps attributes available after commit
+    autoflush=False,
+)
+
+
+# ---- FastAPI dependency ----
+async def get_db() -> AsyncIterator[AsyncSession]:
+    """
+    Yields an AsyncSession to endpoints/services.
+    Ensures proper close even on exception.
+    """
+    async with AsyncSessionLocal() as session:
+        try:
+            yield session
+        finally:
+            # session context manager already closes; explicit for clarity
+            await session.close()
+
+
+# ---- Optional graceful shutdown helpers ----
+async def dispose_engine() -> None:
+    """Call on app shutdown to close the engine cleanly."""
+    await engine.dispose()

--- a/src/db/session.py
+++ b/src/db/session.py
@@ -15,6 +15,7 @@ from src.config.settings import get_settings
 # ---- Declarative base for your ORM models ----
 class Base(DeclarativeBase):
     """Base class for SQLAlchemy ORM models."""
+
     pass
 
 
@@ -24,9 +25,9 @@ _settings = get_settings()
 # Create the async engine from env-driven URL, with sane defaults
 engine: AsyncEngine = create_async_engine(
     _settings.app_db_url,
-    echo=False,           # flip to True locally if you want SQL in logs
-    pool_pre_ping=True,   # validates connections before using them
-    future=True,          # SQLAlchemy 2.0 style
+    echo=False,  # flip to True locally if you want SQL in logs
+    pool_pre_ping=True,  # validates connections before using them
+    future=True,  # SQLAlchemy 2.0 style
 )
 
 # Session factory; each request gets its own session


### PR DESCRIPTION
## What
- Added `src/db/session.py` with SQLAlchemy 2.0 async engine and session factory.
- Implemented `get_db()` FastAPI dependency (per-request session).
- Added optional `dispose_engine()` for clean shutdown.
- Ensured connection URL is read from env-driven settings.

## Why
- Central, reusable DB entry point aligned with async FastAPI.
- Avoids connection leaks and blocking I/O.
- Clear path for adding models and Alembic migrations.

## How to test
1. Start Postgres: `make db-up`
2. Run the smoke test:
   ```bash
   python - <<'PY'
   import asyncio
   from sqlalchemy import text
   from src.db.session import engine
   async def main():
       async with engine.connect() as conn:
           res = await conn.execute(text("SELECT 1"))
           print("DB OK:", res.scalar_one())
   asyncio.run(main())
   PY

✅ Expect DB OK: 1

---

## Common pitfalls & quick fixes
- **Import error for `sqlalchemy` or `asyncpg`:** Install and add to `requirements.txt`.  
- **Connection refused:** `make db-up`, verify `APP_DB_HOST/PORT`, and check `make db-logs`.  
- **Auth failed:** Ensure `.env` matches the credentials in `docker-compose.yml`.

---

## What’s next
- **Init Alembic (async env) + baseline migration.**
- Add your first model (e.g. `Tenant`) and run `alembic revision --autogenerate`.