### PR TITLE
chore(lint): add pre-commit hooks for Ruff and Black

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,11 @@
+repos:
+    - repo: https://github.com/astral-sh/ruff-pre-commit
+      rev: v0.4.7 # use the latest stable Ruff version
+      hooks:
+          - id: ruff
+            args: [--fix]
+
+    - repo: https://github.com/psf/black
+      rev: 23.11.0 # latest stable Black
+      hooks:
+          - id: black


### PR DESCRIPTION
- Added .pre-commit-config.yaml with Ruff (lint + autofix) and Black.
- Installed pre-commit hooks to auto-run on commit.
- Ensures consistent linting/formatting and prevents CI failures.