### PR TITLE
FAQ Bot V1 — Minimal RAG Pipeline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,5 @@ coverage/
 # Data artifacts
 data/
 !data/.gitkeep
+# Allow curated seed data to be versioned
+!data/faqs.yaml

--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,6 @@ data/
 !data/.gitkeep
 # Allow curated seed data to be versioned
 !data/faqs.yaml
+
+# Ignore generated embeddings (commit only if explicitly needed)
+data/*.npy

--- a/README.md
+++ b/README.md
@@ -19,7 +19,9 @@ src/
   api/                  # FastAPI app (REST endpoints)
   ai/
     rag/                # Retrieval-Augmented Generation utilities
-    faq/                # FAQ bot logic (RAG + thresholds + handoff)    forecasting/        # Prophet baseline + interfaces    sentiment/          # Sentiment analysis + action hooks
+    faq/                # FAQ bot logic (RAG + thresholds + handoff)
+    forecasting/        # Prophet baseline + interfaces
+    sentiment/          # Sentiment analysis + action hooks
   clients/              # Integrations (e.g., Google Calendar)
   config/               # App settings, env parsing
   db/

--- a/data/faqs.yaml
+++ b/data/faqs.yaml
@@ -1,0 +1,29 @@
+- id: faq-001
+  question: "How do I book a demo?"
+  answer: "Create a booking via POST /bookings or email demo@example.local."
+  tags: ["booking", "demo"]
+
+- id: faq-002
+  question: "How do I cancel a booking?"
+  answer: "Send DELETE /bookings/{id} or contact support@example.local."
+  tags: ["booking", "cancel"]
+
+- id: faq-003
+  question: "What authentication do you use?"
+  answer: "MVP uses a JWT login stub with role-based routes coming in V2."
+  tags: ["auth"]
+
+- id: faq-004
+  question: "Is my data stored securely?"
+  answer: "Data lives in Postgres; logs are GDPR-safe with basic redaction."
+  tags: ["gdpr", "security"]
+
+- id: faq-005
+  question: "Do you integrate with Google Calendar?"
+  answer: "V2 will sync with Google Calendar; MVP demonstrates local CRUD."
+  tags: ["calendar", "integration"]
+
+- id: faq-006
+  question: "Where can I see the roadmap?"
+  answer: "See docs/roadmap.md and ADRs in /adr for decisions."
+  tags: ["roadmap", "docs"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,6 @@ python-dotenv>=1.0
 alembic>=1.13.2
 psycopg[binary]>=3.1
 email-validator>=2.0
+numpy>=1.26
+PyYAML>=6.0
+sentence-transformers>=2.7

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,0 +1,1 @@
+# Makes this directory a Python package

--- a/src/ai/__init__.py
+++ b/src/ai/__init__.py
@@ -1,0 +1,1 @@
+# Makes this directory a Python package

--- a/src/ai/faq/__init__.py
+++ b/src/ai/faq/__init__.py
@@ -1,0 +1,1 @@
+# Makes this directory a Python package

--- a/src/ai/faq/data_loader.py
+++ b/src/ai/faq/data_loader.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import List
+
+import yaml
+from pydantic import BaseModel
+
+
+class FAQItem(BaseModel):
+    id: str
+    question: str
+    answer: str
+    tags: list[str] | None = None
+
+
+def load_faqs(path: str | Path = "data/faqs.yaml") -> List[FAQItem]:
+    p = Path(path)
+    if not p.exists():
+        return []
+    with p.open("r") as f:
+        raw = yaml.safe_load(f) or []
+    return [FAQItem(**item) for item in raw]

--- a/src/ai/faq/embedder.py
+++ b/src/ai/faq/embedder.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+from pathlib import Path
+import numpy as np
+
+_MODEL_NAME = "sentence-transformers/all-MiniLM-L6-v2"
+_EMB_CACHE = Path("data/faqs_embeddings.npy")
+
+
+class MiniLMEmbedder:
+    """Thin wrapper so we can swap models later without touching callers."""
+
+    def __init__(self) -> None:
+        from sentence_transformers import SentenceTransformer  # lazy import
+
+        self.model = SentenceTransformer(_MODEL_NAME)
+
+    def encode(self, texts: list[str]) -> np.ndarray:
+        vecs = self.model.encode(
+            texts,
+            convert_to_numpy=True,
+            normalize_embeddings=True,  # cosine-ready
+        )
+        return vecs.astype("float32")
+
+
+def load_or_build_embeddings(questions: list[str]) -> tuple[np.ndarray, bool]:
+    """Return (embeddings, used_cache)."""
+    if _EMB_CACHE.exists():
+        return np.load(_EMB_CACHE), True
+    emb = MiniLMEmbedder().encode(questions)
+    return emb, False

--- a/src/ai/faq/retriever.py
+++ b/src/ai/faq/retriever.py
@@ -1,0 +1,9 @@
+from __future__ import annotations
+import numpy as np
+
+
+def cosine_top1(q_vec: np.ndarray, doc_mat: np.ndarray) -> tuple[int, float]:
+    """Return index and similarity (0..1). Assumes vectors are L2-normalised."""
+    sims = doc_mat @ q_vec  # (n,)
+    idx = int(np.argmax(sims))
+    return idx, float(sims[idx])

--- a/src/api/app.py
+++ b/src/api/app.py
@@ -7,6 +7,7 @@ from fastapi import FastAPI
 from sqlalchemy import text
 
 from src.api.routes.bookings import router as bookings_router
+from src.api.routes.faq import router as faq_router  # NEW
 from src.config.settings import get_settings
 from src.db.session import dispose_engine, engine
 
@@ -37,8 +38,10 @@ async def lifespan(app: FastAPI):
 
 def create_app() -> FastAPI:
     app = FastAPI(title="Hybrid AI Platform", lifespan=lifespan)
+
     # Mount routers
     app.include_router(bookings_router)
+    app.include_router(faq_router)  # NEW
 
     @app.get("/health")
     async def health() -> Dict[str, Any]:

--- a/src/api/routes/faq.py
+++ b/src/api/routes/faq.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+from fastapi import APIRouter
+
+from src.ai.faq.data_loader import load_faqs
+from src.ai.faq.embedder import load_or_build_embeddings, MiniLMEmbedder
+from src.ai.faq.retriever import cosine_top1
+from src.api.schemas.faq import FAQAskRequest, FAQAnswer
+
+router = APIRouter(prefix="/faq", tags=["faq"])
+
+# --- Warm state (module-level for simplicity) ---
+_FAQS = load_faqs()
+_QS = [f.question for f in _FAQS]
+_DOC_EMB, _USED_CACHE = load_or_build_embeddings(_QS)
+_EMBEDDER = None if _USED_CACHE else MiniLMEmbedder()
+
+
+@router.post("/ask", response_model=FAQAnswer)
+async def ask(req: FAQAskRequest) -> FAQAnswer:
+    """Return top-1 FAQ answer with similarity score."""
+    if _EMBEDDER is None:
+        # If embeddings were loaded from cache, we still need an encoder for the query.
+        q_emb = MiniLMEmbedder().encode([req.question])[0]
+    else:
+        q_emb = _EMBEDDER.encode([req.question])[0]
+
+    idx, score = cosine_top1(q_emb, _DOC_EMB)
+    item = _FAQS[idx]
+    return FAQAnswer(answer=item.answer, score=score, source_id=item.id)

--- a/src/api/schemas/faq.py
+++ b/src/api/schemas/faq.py
@@ -1,0 +1,13 @@
+# src/api/schemas/faq.py
+from __future__ import annotations
+from pydantic import BaseModel, Field
+
+
+class FAQAskRequest(BaseModel):
+    question: str = Field(min_length=1, max_length=500)
+
+
+class FAQAnswer(BaseModel):
+    answer: str
+    score: float
+    source_id: str

--- a/tests/integration/test_faq_api.py
+++ b/tests/integration/test_faq_api.py
@@ -1,0 +1,42 @@
+import types
+import numpy as np
+import pytest
+from httpx import AsyncClient
+from httpx import ASGITransport  # NEW
+from asgi_lifespan import LifespanManager
+
+from src.api.app import app
+
+
+@pytest.mark.asyncio
+async def test_faq_ask_returns_answer(monkeypatch):
+    import src.api.routes.faq as faq_mod
+
+    class FakeEmbedder:
+        def encode(self, texts):
+            arr = [np.array([1.0, 0.0], dtype="float32") for _ in texts]
+            return np.vstack(arr)
+
+    faqs = [
+        types.SimpleNamespace(
+            id="faq-001", question="How do I book a demo?", answer="Use /bookings."
+        ),
+        types.SimpleNamespace(id="faq-002", question="Something else?", answer="Another answer."),
+    ]
+    doc_emb = np.array([[1.0, 0.0], [0.0, 1.0]], dtype="float32")
+
+    monkeypatch.setattr(faq_mod, "_FAQS", faqs, raising=False)
+    monkeypatch.setattr(faq_mod, "_DOC_EMB", doc_emb, raising=False)
+    monkeypatch.setattr(faq_mod, "_EMBEDDER", FakeEmbedder(), raising=False)
+
+    transport = ASGITransport(app=app)  # NEW
+
+    async with LifespanManager(app):
+        async with AsyncClient(transport=transport, base_url="http://test") as ac:  # CHANGED
+            res = await ac.post("/faq/ask", json={"question": "demo booking please"})
+
+    assert res.status_code == 200
+    data = res.json()
+    assert data["answer"] == "Use /bookings."
+    assert data["source_id"] == "faq-001"
+    assert 0.0 <= data["score"] <= 1.0

--- a/tests/unit/test_faq_loader.py
+++ b/tests/unit/test_faq_loader.py
@@ -1,0 +1,20 @@
+from pathlib import Path
+import textwrap
+from src.ai.faq.data_loader import load_faqs
+
+
+def test_load_faqs_parses_yaml(tmp_path: Path):
+    p = tmp_path / "faqs.yaml"
+    p.write_text(
+        textwrap.dedent(
+            """
+        - id: x
+          question: "Q?"
+          answer: "A."
+    """
+        ).strip()
+    )
+    faqs = load_faqs(p)
+    assert len(faqs) == 1
+    assert faqs[0].id == "x"
+    assert faqs[0].answer == "A."

--- a/tests/unit/test_faq_retriever.py
+++ b/tests/unit/test_faq_retriever.py
@@ -1,0 +1,11 @@
+import numpy as np
+from src.ai.faq.retriever import cosine_top1
+
+
+def test_cosine_top1_selects_highest():
+    # Two orthogonal docs; query matches the first doc exactly.
+    docs = np.array([[1.0, 0.0], [0.0, 1.0]], dtype="float32")
+    q = np.array([1.0, 0.0], dtype="float32")
+    idx, score = cosine_top1(q, docs)
+    assert idx == 0
+    assert score == 1.0


### PR DESCRIPTION
# PR: FAQ Bot V1 — Minimal RAG Pipeline

## Context
This PR delivers the Week 4 FAQ Bot (V1) sprint task.  
Goal: build a minimal retrieval-based FAQ Bot that answers from 5–10 curated FAQs via `/faq/ask`. When integrated with handoff in the next issue, this forms the foundation of a reliable, enterprise-ready assistant.

## What’s included
- **FAQ data loader**  
  - `src/ai/faq/data_loader.py`: `FAQItem` Pydantic model and `load_faqs()` YAML parser.  
- **Curated seed FAQs**  
  - `data/faqs.yaml` with 6 demo-ready FAQs.  
  - `.gitignore` updated to allow YAML while ignoring generated artefacts (for example, embeddings).  
- **Router integration**  
  - New FastAPI router at `/faq/ask`.  
  - Wired into `src/api/app.py`.  
- **Embedding and retrieval utilities**  
  - `embedder.py` and `retriever.py` under `src/ai/faq/`.  
- **Tests**  
  - Unit: retriever scoring, FAQ loader parsing.  
  - Integration: `/faq/ask` endpoint with mocked embedder (no model download).  
- **Packaging fixes**  
  - Added `__init__.py` to `src/`, `src/ai/`, and `src/ai/faq/` for stable imports.  
- **Integration test update**  
  - Switched to `httpx.ASGITransport` for compatibility with httpx >=0.27.

## Why this matters
- Keeps costs at zero — runs locally without paid services.  
- Deterministic behaviour — every question gets a reproducible answer.  
- CI remains green — tests mock embeddings, no external downloads required.  
- Professional engineering hygiene — modular code, ADR alignment, clear tests, and Conventional Commits.

## Checklist
- [x] Seed FAQ dataset (`data/faqs.yaml`)  
- [x] Loader and retriever utilities  
- [x] New `/faq/ask` endpoint  
- [x] Unit and integration tests (mocked for CI)  
- [x] Docs and `.gitignore` adjustments  
- [x] All tests passing locally and in CI  

## Linked Issue
Closes #<ISSUE_NUMBER>

## Outcome
With this merged, the FAQ Bot V1 can reliably answer FAQs from a curated dataset. The next step is to add a confidence threshold and email handoff (ADR-006 follow-up).
