### PR TITLE
Feature/faq bot threshold

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -17,3 +17,11 @@ APP_DB_URL=postgresql+asyncpg://${APP_DB_USER}:${APP_DB_PASSWORD}@${APP_DB_HOST}
 PGADMIN_EMAIL=admin@example.com
 PGADMIN_PASSWORD=adminpass
 
+# FAQ Bot
+FAQ_CONFIDENCE_THRESHOLD=0.60
+
+# Email handoff (for dev with MailHog)
+# SMTP_HOST=localhost
+# SMTP_PORT=1025
+# SMTP_FROM=bot@local.test
+# HANDOFF_TO=founder@local.test

--- a/.env.example
+++ b/.env.example
@@ -21,6 +21,11 @@ PGADMIN_PASSWORD=adminpass
 FAQ_CONFIDENCE_THRESHOLD=0.60
 
 # Email handoff (for dev with MailHog)
+SMTP_HOST=localhost
+SMTP_PORT=1025
+SMTP_FROM=bot@local.test
+HANDOFF_TO=founder@local.test
+
 # SMTP_HOST=localhost
 # SMTP_PORT=1025
 # SMTP_FROM=bot@local.test

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ before executing tests to ensure the schema is always up to date.
 
 See `/docs/roadmap.md` (placeholder) and ADRs in `/adr` for decisions.# trigger ci
 
-## FAQ BOT (V1)
+### FAQ BOT (V1)
 
 The FAQ Bot is a minimal retrieval-based assistant. It loads a small set of curated FAQs `from data/faqs.yaml`, encodes them into embeddings, and serves answers through a FastAPI endpoint.
 This approach keeps costs at zero (no paid APIs) and ensures deterministic behaviour. If a question is close enough to one of the stored FAQs, the corresponding answer is returned.
@@ -132,6 +132,18 @@ curl -X POST http://localhost:8000/faq/ask \
 -   **Retrieval:** Cosine similarity is used to find the closest match.
 -   **API contract:** `POST /faq/ask` with a question returns the best-matched FAQ answer.
 -   **Tests:** Unit and integration tests validate retrieval behaviour without requiring external services.
+
+### Confidence and fallback
+
+The service normalises cosine similarity to `[0,1]` and compares it with `FAQ_CONFIDENCE_THRESHOLD` (default `0.60`).  
+If the score is below the threshold, the endpoint returns a `handoff` response and triggers an email to a human inbox.
+
+**Local email (MailHog):**
+
+```bash
+docker run -d --name mailhog -p 1025:1025 -p 8025:8025 mailhog/mailhog
+open http://localhost:8025
+```
 
 ## Branching & PRs (modern Git)
 

--- a/README.md
+++ b/README.md
@@ -135,8 +135,18 @@ curl -X POST http://localhost:8000/faq/ask \
 
 ### Confidence and fallback
 
-The service normalises cosine similarity to `[0,1]` and compares it with `FAQ_CONFIDENCE_THRESHOLD` (default `0.60`).  
-If the score is below the threshold, the endpoint returns a `handoff` response and triggers an email to a human inbox.
+Each FAQ answer is returned with a **confidence score** between 0 and 1.  
+This score is derived from cosine similarity and normalised by `(cosine + 1) / 2`.
+
+-   If the score is **greater than or equal to** the configured threshold (`FAQ_CONFIDENCE_THRESHOLD`, default `0.60`), the FAQ Bot returns the curated answer and its source id.
+-   If the score is **below** the threshold, the bot does **not** guess. Instead, it:
+    1. Returns a `handoff` response in the API output.
+    2. Triggers an **email notification** (via SMTP, e.g. MailHog in local dev) containing:
+        - The user’s original question
+        - The closest FAQ match (id, question, answer)
+        - The score and threshold values
+
+This design ensures graceful fallback: users aren’t misled by low-confidence answers, and humans stay in the loop for questions outside the curated set.
 
 **Local email (MailHog):**
 

--- a/src/ai/faq/notify.py
+++ b/src/ai/faq/notify.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+import smtplib
+from email.message import EmailMessage
+from dataclasses import dataclass
+
+from src.config.settings import Settings
+
+
+@dataclass
+class FAQContext:
+    id: str
+    question: str
+    answer: str
+
+
+def _build_message(settings: Settings, to_addr: str, subject: str, body: str) -> EmailMessage:
+    msg = EmailMessage()
+    msg["From"] = settings.smtp_from or "bot@local.test"
+    msg["To"] = to_addr
+    msg["Subject"] = subject
+    msg.set_content(body)
+    return msg
+
+
+def send_handoff_email(
+    settings: Settings,
+    user_question: str,
+    top_faq: FAQContext,
+    score: float,
+    threshold: float,
+) -> bool:
+    """
+    Send a handoff email. Returns True if we attempted to send; False if not configured.
+    Designed to be easily monkeypatched in tests (no network).
+    """
+    if not (settings.smtp_host and settings.smtp_port and settings.handoff_to):
+        # Not configured -> no-op
+        return False
+
+    subject = f"[FAQ Bot] Handoff triggered (score={score:.2f} < thr={threshold:.2f})"
+    body = (
+        "A low-confidence FAQ query needs human attention.\n\n"
+        f"User question:\n{user_question}\n\n"
+        "Top retrieved context:\n"
+        f"- id: {top_faq.id}\n"
+        f"- question: {top_faq.question}\n"
+        f"- answer: {top_faq.answer}\n\n"
+        f"Score: {score:.3f}\n"
+        f"Threshold: {threshold:.3f}\n"
+    )
+
+    msg = _build_message(settings, settings.handoff_to, subject, body)
+
+    with smtplib.SMTP(settings.smtp_host, int(settings.smtp_port)) as smtp:
+        # MailHog requires no TLS/auth
+        smtp.send_message(msg)
+
+    return True

--- a/src/ai/faq/retriever.py
+++ b/src/ai/faq/retriever.py
@@ -1,9 +1,22 @@
+# src/ai/faq/retriever.py
 from __future__ import annotations
 import numpy as np
 
 
 def cosine_top1(q_vec: np.ndarray, doc_mat: np.ndarray) -> tuple[int, float]:
-    """Return index and similarity (0..1). Assumes vectors are L2-normalised."""
+    """
+    Return (index, cosine) where cosine is in [-1, 1].
+    Assumes q_vec and each row of doc_mat are L2-normalised.
+    """
     sims = doc_mat @ q_vec  # (n,)
     idx = int(np.argmax(sims))
     return idx, float(sims[idx])
+
+
+def score_from_cosine(cosine: float) -> float:
+    """
+    Map cosine in [-1, 1] to a user-facing score in [0, 1].
+    """
+    # Clamp then rescale
+    c = max(-1.0, min(1.0, float(cosine)))
+    return (c + 1.0) / 2.0

--- a/src/api/routes/faq.py
+++ b/src/api/routes/faq.py
@@ -8,6 +8,7 @@ from src.ai.faq.embedder import load_or_build_embeddings, MiniLMEmbedder
 from src.ai.faq.retriever import cosine_top1, score_from_cosine
 from src.api.schemas.faq import FAQAskRequest, FAQAnswer, FAQHandoff
 from src.config.settings import get_settings
+from src.ai.faq.notify import send_handoff_email, FAQContext
 
 router = APIRouter(prefix="/faq", tags=["faq"])
 settings = get_settings()
@@ -49,7 +50,18 @@ async def ask(req: FAQAskRequest):
 
     # Threshold check
     if score < settings.faq_confidence_threshold:
-        # Below confidence -> return handoff signal for next step (SMTP)
+        # Prepare minimal context for the email
+        item = _FAQS[idx]  # type: ignore[index]
+        ctx = FAQContext(id=item.id, question=item.question, answer=item.answer)
+        # Fire-and-forget: we call synchronously here (simple & OK for dev);
+        # could switch to BackgroundTasks later.
+        _ = send_handoff_email(
+            settings=settings,
+            user_question=req.question,
+            top_faq=ctx,
+            score=score,
+            threshold=settings.faq_confidence_threshold,
+        )
         return FAQHandoff(handoff=True, score=score, question=req.question)
 
     # Confident -> return curated answer

--- a/src/api/routes/faq.py
+++ b/src/api/routes/faq.py
@@ -21,10 +21,12 @@ _EMBEDDER: MiniLMEmbedder | None = None
 @router.on_event("startup")
 async def _warm_faq_state() -> None:
     global _FAQS, _DOC_EMB, _EMBEDDER
-    _FAQS = load_faqs()
-    qs = [f.question for f in _FAQS]
-    _DOC_EMB, used_cache = load_or_build_embeddings(qs)
-    _EMBEDDER = None if used_cache else MiniLMEmbedder()
+    # Only initialise if not already set (helps tests that monkeypatch state)
+    if _FAQS is None or _DOC_EMB is None:
+        _FAQS = load_faqs()
+        qs = [f.question for f in _FAQS]
+        _DOC_EMB, used_cache = load_or_build_embeddings(qs)
+        _EMBEDDER = None if used_cache else MiniLMEmbedder()
 
 
 @router.post(

--- a/src/api/routes/faq.py
+++ b/src/api/routes/faq.py
@@ -1,29 +1,55 @@
 from __future__ import annotations
+
 from fastapi import APIRouter
+import numpy as np
 
 from src.ai.faq.data_loader import load_faqs
 from src.ai.faq.embedder import load_or_build_embeddings, MiniLMEmbedder
-from src.ai.faq.retriever import cosine_top1
-from src.api.schemas.faq import FAQAskRequest, FAQAnswer
+from src.ai.faq.retriever import cosine_top1, score_from_cosine
+from src.api.schemas.faq import FAQAskRequest, FAQAnswer, FAQHandoff
+from src.config.settings import get_settings
 
 router = APIRouter(prefix="/faq", tags=["faq"])
+settings = get_settings()
 
-# --- Warm state (module-level for simplicity) ---
-_FAQS = load_faqs()
-_QS = [f.question for f in _FAQS]
-_DOC_EMB, _USED_CACHE = load_or_build_embeddings(_QS)
-_EMBEDDER = None if _USED_CACHE else MiniLMEmbedder()
+# --- Lazy-initialised state (safe for tests) ---
+_FAQS: list | None = None
+_DOC_EMB: np.ndarray | None = None
+_EMBEDDER: MiniLMEmbedder | None = None
 
 
-@router.post("/ask", response_model=FAQAnswer)
-async def ask(req: FAQAskRequest) -> FAQAnswer:
-    """Return top-1 FAQ answer with similarity score."""
+@router.on_event("startup")
+async def _warm_faq_state() -> None:
+    global _FAQS, _DOC_EMB, _EMBEDDER
+    _FAQS = load_faqs()
+    qs = [f.question for f in _FAQS]
+    _DOC_EMB, used_cache = load_or_build_embeddings(qs)
+    _EMBEDDER = None if used_cache else MiniLMEmbedder()
+
+
+@router.post(
+    "/ask",
+    response_model=FAQAnswer | FAQHandoff,  # can return either shape
+)
+async def ask(req: FAQAskRequest):
+    # init-on-first-call fallback (for tests that don’t run startup)
+    global _FAQS, _DOC_EMB, _EMBEDDER
+    if _FAQS is None or _DOC_EMB is None:
+        await _warm_faq_state()  # type: ignore[misc]
+
     if _EMBEDDER is None:
-        # If embeddings were loaded from cache, we still need an encoder for the query.
         q_emb = MiniLMEmbedder().encode([req.question])[0]
     else:
         q_emb = _EMBEDDER.encode([req.question])[0]
 
-    idx, score = cosine_top1(q_emb, _DOC_EMB)
-    item = _FAQS[idx]
+    idx, cosine = cosine_top1(q_emb, _DOC_EMB)  # type: ignore[arg-type]
+    score = score_from_cosine(cosine)
+
+    # Threshold check
+    if score < settings.faq_confidence_threshold:
+        # Below confidence -> return handoff signal for next step (SMTP)
+        return FAQHandoff(handoff=True, score=score, question=req.question)
+
+    # Confident -> return curated answer
+    item = _FAQS[idx]  # type: ignore[index]
     return FAQAnswer(answer=item.answer, score=score, source_id=item.id)

--- a/src/api/schemas/faq.py
+++ b/src/api/schemas/faq.py
@@ -1,13 +1,22 @@
-# src/api/schemas/faq.py
 from __future__ import annotations
-from pydantic import BaseModel, Field
+from pydantic import BaseModel
+from typing import Annotated
+from pydantic import StringConstraints
+
+Question = Annotated[str, StringConstraints(min_length=1, max_length=500)]
 
 
 class FAQAskRequest(BaseModel):
-    question: str = Field(min_length=1, max_length=500)
+    question: Question
 
 
 class FAQAnswer(BaseModel):
     answer: str
     score: float
     source_id: str
+
+
+class FAQHandoff(BaseModel):
+    handoff: bool = True
+    score: float
+    question: str

--- a/src/config/settings.py
+++ b/src/config/settings.py
@@ -1,42 +1,57 @@
+# src/config/settings.py
+from __future__ import annotations
+
 from functools import lru_cache
-from pydantic import field_validator
+from pydantic import field_validator, ValidationInfo
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
 class Settings(BaseSettings):
-    # Read from .env; ignore unexpected keys to be resilient
-    model_config = SettingsConfigDict(
-        env_file=".env",
-        case_sensitive=False,
-        extra="ignore",  # <- important: don't error on unrelated env vars
-    )
+    # --- FAQ Bot ---
+    # Confidence threshold in [0,1]
+    faq_confidence_threshold: float = 0.60
 
-    # General
-    app_env: str = "local"  # maps to APP_ENV
-    debug: bool = True  # maps to DEBUG
+    # --- General ---
+    app_env: str = "local"  # maps from APP_ENV (case-insensitive)
+    debug: bool = True  # maps from DEBUG
 
-    # DB pieces
+    # --- Database ---
     app_db_user: str = "appuser"
     app_db_password: str = "apppass"
     app_db_name: str = "appdb"
     app_db_host: str = "localhost"
     app_db_port: int = 5432
-    app_db_url: str | None = None  # optional override
+    app_db_url: str | None = None  # optional override (takes precedence)
 
-    # Optional pgAdmin (present in .env for docker-compose)
-    pgadmin_email: str | None = None  # maps to PGADMIN_EMAIL
-    pgadmin_password: str | None = None  # maps to PGADMIN_PASSWORD
+    # --- Optional pgAdmin (docker compose) ---
+    pgadmin_email: str | None = None
+    pgadmin_password: str | None = None
+
+    # --- Email handoff (used in the next task; safe to keep default/None now) ---
+    smtp_host: str | None = None  # e.g. "localhost" for MailHog
+    smtp_port: int | None = None  # e.g. 1025 for MailHog
+    smtp_from: str | None = None  # e.g. "bot@local.test"
+    handoff_to: str | None = None  # e.g. "founder@local.test"
+
+    # --- Settings config ---
+    model_config = SettingsConfigDict(
+        env_file=".env",
+        case_sensitive=False,  # allow APP_ENV or app_env etc.
+        extra="ignore",  # ignore unknown env vars
+    )
 
     @field_validator("app_db_url", mode="before")
     @classmethod
-    def assemble_db_url(cls, v: str | None, values: dict):
+    def assemble_db_url(cls, v: str | None, info: ValidationInfo) -> str:
+        """If APP_DB_URL is not provided, build it from the individual parts."""
         if v:
             return v
-        user = values.get("app_db_user")
-        pw = values.get("app_db_password")
-        host = values.get("app_db_host")
-        port = values.get("app_db_port")
-        name = values.get("app_db_name")
+        data = info.data
+        user = data.get("app_db_user", "appuser")
+        pw = data.get("app_db_password", "apppass")
+        host = data.get("app_db_host", "localhost")
+        port = data.get("app_db_port", 5432)
+        name = data.get("app_db_name", "appdb")
         return f"postgresql+asyncpg://{user}:{pw}@{host}:{port}/{name}"
 
 

--- a/tests/integration/test_faq_threshold.py
+++ b/tests/integration/test_faq_threshold.py
@@ -1,0 +1,41 @@
+import types
+import numpy as np
+import pytest
+from httpx import AsyncClient, ASGITransport
+from asgi_lifespan import LifespanManager
+from src.api.app import app
+
+
+@pytest.mark.asyncio
+async def test_faq_ask_below_threshold_triggers_handoff(monkeypatch):
+    import src.api.routes.faq as faq_mod
+
+    # Fake embedder: query vector is [1,0]
+    class FakeEmbedder:
+        def encode(self, texts):
+            return np.vstack([np.array([1.0, 0.0], dtype="float32") for _ in texts])
+
+    # One document with cosine=0.6 against query -> score=(0.6+1)/2=0.8
+    faqs = [
+        types.SimpleNamespace(id="faq-low", question="Low-sim question", answer="Low-sim answer")
+    ]
+    doc_emb = np.array([[0.6, 0.8]], dtype="float32")  # unit length
+
+    # Patch runtime state and raise the threshold to 0.95 to force handoff
+    monkeypatch.setattr(faq_mod, "_FAQS", faqs, raising=False)
+    monkeypatch.setattr(faq_mod, "_DOC_EMB", doc_emb, raising=False)
+    monkeypatch.setattr(faq_mod, "_EMBEDDER", FakeEmbedder(), raising=False)
+    monkeypatch.setattr(faq_mod.settings, "faq_confidence_threshold", 0.95, raising=False)
+
+    transport = ASGITransport(app=app)
+    async with LifespanManager(app):
+        async with AsyncClient(transport=transport, base_url="http://test") as ac:
+            res = await ac.post("/faq/ask", json={"question": "will this hand off?"})
+
+    assert res.status_code == 200
+    data = res.json()
+    # Handoff payload expected
+    assert data.get("handoff") is True
+    assert "question" in data and "score" in data
+    # No 'answer' or 'source_id' in handoff response
+    assert "answer" not in data and "source_id" not in data

--- a/tests/integration/test_faq_threshold.py
+++ b/tests/integration/test_faq_threshold.py
@@ -3,25 +3,31 @@ import numpy as np
 import pytest
 from httpx import AsyncClient, ASGITransport
 from asgi_lifespan import LifespanManager
+
 from src.api.app import app
 
 
 @pytest.mark.asyncio
 async def test_faq_ask_below_threshold_triggers_handoff(monkeypatch):
+    """
+    When score < threshold, the endpoint should return a handoff payload
+    (no answer/source_id) and include the question and score.
+    """
     import src.api.routes.faq as faq_mod
 
-    # Fake embedder: query vector is [1,0]
+    # Fake embedder: query vector is [1, 0]
     class FakeEmbedder:
         def encode(self, texts):
             return np.vstack([np.array([1.0, 0.0], dtype="float32") for _ in texts])
 
-    # One document with cosine=0.6 against query -> score=(0.6+1)/2=0.8
+    # One doc with cosine=0.6 vs query -> score=(0.6+1)/2=0.8
     faqs = [
         types.SimpleNamespace(id="faq-low", question="Low-sim question", answer="Low-sim answer")
     ]
     doc_emb = np.array([[0.6, 0.8]], dtype="float32")  # unit length
 
-    # Patch runtime state and raise the threshold to 0.95 to force handoff
+    # Patch runtime state and raise the threshold to 0.95 to force handoff.
+    # Note: router startup is idempotent; it won't overwrite pre-set values.
     monkeypatch.setattr(faq_mod, "_FAQS", faqs, raising=False)
     monkeypatch.setattr(faq_mod, "_DOC_EMB", doc_emb, raising=False)
     monkeypatch.setattr(faq_mod, "_EMBEDDER", FakeEmbedder(), raising=False)
@@ -39,3 +45,46 @@ async def test_faq_ask_below_threshold_triggers_handoff(monkeypatch):
     assert "question" in data and "score" in data
     # No 'answer' or 'source_id' in handoff response
     assert "answer" not in data and "source_id" not in data
+
+
+@pytest.mark.asyncio
+async def test_faq_ask_below_threshold_triggers_email(monkeypatch):
+    """
+    When score < threshold, the router should invoke the email helper.
+    We spy on send_handoff_email and assert it is called exactly once.
+    """
+    import src.api.routes.faq as faq_mod
+    import src.ai.faq.notify as notify_mod
+
+    # Fake embedder: query vector is [1, 0]
+    class FakeEmbedder:
+        def encode(self, texts):
+            return np.vstack([np.array([1.0, 0.0], dtype="float32") for _ in texts])
+
+    # Keep cosine modest and push threshold high to guarantee handoff
+    faqs = [types.SimpleNamespace(id="faq-low", question="Low?", answer="Low A.")]
+    # cos ~ 0.5 -> score 0.75
+    doc_emb = np.array([[0.5, 0.8660254]], dtype="float32")  # already L2-normalised
+
+    # Patch router state
+    monkeypatch.setattr(faq_mod, "_FAQS", faqs, raising=False)
+    monkeypatch.setattr(faq_mod, "_DOC_EMB", doc_emb, raising=False)
+    monkeypatch.setattr(faq_mod, "_EMBEDDER", FakeEmbedder(), raising=False)
+    monkeypatch.setattr(faq_mod.settings, "faq_confidence_threshold", 0.95, raising=False)
+
+    # Spy on the email sender
+    calls = {"n": 0}
+
+    def fake_send_handoff_email(*args, **kwargs):
+        calls["n"] += 1
+        return True
+
+    monkeypatch.setattr(notify_mod, "send_handoff_email", fake_send_handoff_email, raising=False)
+
+    transport = ASGITransport(app=app)
+    async with LifespanManager(app):
+        async with AsyncClient(transport=transport, base_url="http://test") as ac:
+            res = await ac.post("/faq/ask", json={"question": "trigger email?"})
+
+    assert res.status_code == 200
+    assert calls["n"] == 1  # email helper was invoked once

--- a/tests/unit/test_faq_notify.py
+++ b/tests/unit/test_faq_notify.py
@@ -1,0 +1,43 @@
+from src.ai.faq.notify import send_handoff_email, FAQContext
+from src.config.settings import Settings
+
+
+class DummySMTP:
+    last_msg = None
+
+    def __init__(self, host, port):
+        self.host, self.port = host, port
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+    def send_message(self, msg):
+        DummySMTP.last_msg = msg
+
+
+def test_send_handoff_email_builds_and_sends(monkeypatch):
+    # Patch smtplib.SMTP to our dummy
+    import smtplib
+
+    monkeypatch.setattr(smtplib, "SMTP", DummySMTP)
+
+    settings = Settings(
+        smtp_host="localhost",
+        smtp_port=1025,
+        smtp_from="bot@local.test",
+        handoff_to="founder@local.test",
+    )
+    ok = send_handoff_email(
+        settings,
+        user_question="What is the SLA?",
+        top_faq=FAQContext(id="faq-001", question="SLA?", answer="99.9%"),
+        score=0.42,
+        threshold=0.60,
+    )
+    assert ok is True
+    assert DummySMTP.last_msg["To"] == "founder@local.test"
+    assert "Handoff triggered" in DummySMTP.last_msg["Subject"]
+    assert "User question:" in DummySMTP.last_msg.get_content()

--- a/tests/unit/test_faq_scoring.py
+++ b/tests/unit/test_faq_scoring.py
@@ -1,0 +1,10 @@
+from src.ai.faq.retriever import score_from_cosine
+
+
+def test_score_from_cosine_bounds():
+    assert score_from_cosine(-1.0) == 0.0
+    assert score_from_cosine(1.0) == 1.0
+
+
+def test_score_from_cosine_midpoint():
+    assert score_from_cosine(0.0) == 0.5


### PR DESCRIPTION
# PR: FAQ Bot — Confidence Threshold and Email Handoff

## Context
This PR delivers the second part of the FAQ Bot (Sprint 4) work: adding confidence scoring and a graceful human handoff mechanism.  
When the bot is not confident in an answer, it no longer guesses — instead, it signals a handoff and notifies a human via email.

## What’s included
- **Confidence scoring**
  - Added `score_from_cosine` utility to normalise similarity to `[0,1]`.
  - `FAQ_CONFIDENCE_THRESHOLD` setting (default `0.60`) added to config and `.env.example`.
  - Router logic updated to branch on threshold.
- **Handoff behaviour**
  - New response model (`FAQHandoff`) for low-confidence queries.
  - Introduced `send_handoff_email` helper in `src/ai/faq/notify.py`.
  - On low confidence, bot returns `handoff` response and triggers an email containing:
    - The user’s original question
    - The closest FAQ match (id, question, answer)
    - The score and configured threshold
- **Tests**
  - Unit tests for score normalisation and email helper (mock SMTP).
  - Integration tests to validate:
    - Handoff response returned when below threshold
    - Email helper invoked on handoff
- **Documentation**
  - Updated README with a “Confidence and Fallback” section explaining:
    - How scoring and thresholding works
    - How to test email handoff locally with MailHog
  - `.env.example` updated with SMTP variables.

## Why this matters
- Prevents the bot from returning misleading answers on low confidence.
- Ensures a graceful fallback path with human-in-the-loop handoff.
- Keeps costs at zero using local SMTP (MailHog in dev).
- Demonstrates professional engineering hygiene: modular code, tested paths, and clear documentation.

## Checklist
- [x] Confidence score normalisation implemented
- [x] Threshold check added to router
- [x] SMTP/email handoff helper created
- [x] Unit and integration tests added
- [x] README updated with fallback behaviour and MailHog setup
- [x] `.env.example` updated with SMTP config

## Linked Issue
Closes #27 

## Outcome
With this merged, the FAQ Bot now gracefully handles low-confidence queries by signalling a handoff and notifying a human. This completes the “Confidence Threshold + Email Handoff” sprint task.
